### PR TITLE
Feature/add macos notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,19 @@ git push origin v1.0.0
 5. Test the Formula locally to ensure it downloads and installs correctly.
 6. Commit and push the new formula to the homebrew-gpush repo
 
+## Notifications
+
+Because builds can take a while, there is a notification system in place to let you know when the build is complete.
+*This is a MacOS only feature at this time.*
+
+To enable this, install `terminal-notifier` with your favorite packager, for example `brew install terminal-notifier`. 
+You can suppress notifications by setting the env `GPUSH_NO_NOTIFIER=1`.
+
+Your preferred success or fail sound effects will play if you set env `GPUSH_SOUND_SUCCESS` and/or `GPUSH_SOUND_FAIL` to the path
+of a sound file. Good starting points for these are:
+ - https://pixabay.com/sound-effects/wah-wah-sad-trombone-6347/
+ - https://pixabay.com/sound-effects/tada-fanfare-a-6313/
+
 ## Homebrew Core Submission Next Steps:
 
 Increase notability by upping GitHub stars, watchers, and forks

--- a/gpushrc_debug.yml
+++ b/gpushrc_debug.yml
@@ -1,0 +1,27 @@
+# try me with: src/ruby/gpush.rb -v --dry-run --config gpushrc_debug.yml
+gpush_version: ">=2.4.1"
+success_emoji: "🐞"
+
+get_specs:
+  include_pattern: spec/**/*spec.rb
+
+pre_run:
+   - name: set up hello world
+     shell: echo ">>> HELLO WORLD DEBUG CONFIG"
+
+parallel_run:
+  - name: succeed me
+    shell: sleep 1 && true
+
+  - name: fail me
+    shell: sleep 1 && false # comment me out to "succeed"
+
+post_run:
+  - shell: echo ">>> GOODBYE WORLD 1" # && false
+  - shell: echo ">>> GOODBYE WORLD 2"
+
+post_run_success:
+  - shell: echo ">>> GOODBYE WORLD SUCCESS"
+
+post_run_failure:
+  - shell: echo ">>> GOODBYE WORLD FAILURE"

--- a/gpushrc_debug.yml
+++ b/gpushrc_debug.yml
@@ -1,4 +1,4 @@
-# try me with: src/ruby/gpush.rb -v --dry-run --config gpushrc_debug.yml
+# try me with: src/ruby/gpush.rb -v --dry-run --config_file gpushrc_debug.yml
 gpush_version: ">=2.4.1"
 success_emoji: "🐞"
 

--- a/spec/gpush_alt_config.yml
+++ b/spec/gpush_alt_config.yml
@@ -1,0 +1,6 @@
+pre_run:
+  - shell: echo "Pre-run command in spec/gpush_alt_config.yml"
+
+parallel_run:
+  - name: parallel_run_1
+    shell: echo "Parallel run 1 in spec/gpush_alt_config.yml"

--- a/spec/gpush_spec.rb
+++ b/spec/gpush_spec.rb
@@ -1,4 +1,5 @@
 require "rspec"
+ENV["GPUSH_VERSION"] = "2.0.0"
 require_relative "../src/ruby/gpush.rb"
 require_relative "./mock_system.rb"
 
@@ -42,6 +43,22 @@ RSpec.describe "Gpush" do
     expect { go(dry_run: true, verbose: true) }.to output(
       /#{Regexp.escape("Current directory in braces: [#{__dir__}/directory_with_config]")}/xm,
     ).to_stdout
+  end
+
+  it "accepts a custom config file" do
+    expect {
+      go(dry_run: true, verbose: true, config_file: "gpush_alt_config.yml")
+    }.to output(
+      /#{Regexp.escape("Using config file: spec/gpush_alt_config.yml")}/xm,
+    ).to_stdout
+  end
+
+  it "complains if the custom config file does not exist" do
+    expect {
+      go(dry_run: true, verbose: true, config_file: "non_existent.yml")
+    }.to raise_error(SystemExit).and output(
+            /#{Regexp.escape("Config file not found: non_existent.yml")}/m,
+          ).to_stdout
   end
 
   it "aborts if gpush_version in the config file is not compatible" do

--- a/spec/gpush_spec.rb
+++ b/spec/gpush_spec.rb
@@ -1,5 +1,5 @@
+ENV["GPUSH_VERSION"] ||= "2.0.0"
 require "rspec"
-ENV["GPUSH_VERSION"] = "2.0.0"
 require_relative "../src/ruby/gpush.rb"
 require_relative "./mock_system.rb"
 

--- a/src/ruby/gpush.rb
+++ b/src/ruby/gpush.rb
@@ -9,7 +9,7 @@ require_relative "notifier" # Import the desktop notifier
 
 EXITING_MESSAGE = "\nExiting gpush.".freeze
 
-DEFAULT_VERSION = "unknown".freeze # Default for uninstalled scripts
+DEFAULT_VERSION = "local-development".freeze # Default for uninstalled scripts
 VERSION = ENV["GPUSH_VERSION"] || DEFAULT_VERSION
 
 def parse_config(config_file = nil)

--- a/src/ruby/gpush.rb
+++ b/src/ruby/gpush.rb
@@ -11,8 +11,11 @@ EXITING_MESSAGE = "\nExiting gpush.".freeze
 DEFAULT_VERSION = "unknown".freeze # Default for uninstalled scripts
 VERSION = ENV["GPUSH_VERSION"] || DEFAULT_VERSION
 
-def parse_config
+def parse_config(config_file = nil)
   config_names = %w[gpushrc.yml gpushrc.yaml] # Possible config filenames.
+  unless config_file.nil?
+    config_names.unshift(config_file) # Command line option takes precedence.
+  end
   looking_in_dir = Dir.pwd # Start in the current working directory.
   config_file = nil
 
@@ -77,7 +80,7 @@ def simple_run_commands_with_output(commands, title:, verbose:)
   puts "\n\n"
 end
 
-def go(dry_run: false, verbose: false)
+def go(dry_run: false, verbose: false, config_file: nil)
   GpushOptionsParser.check_version(VERSION)
   puts "Starting dry run" if dry_run
 
@@ -131,7 +134,7 @@ def go(dry_run: false, verbose: false)
     end
   end
 
-  config = parse_config
+  config = parse_config(config_file)
 
   pre_run_commands = config["pre_run"] || []
   parallel_run_commands = config["parallel_run"] || []
@@ -214,8 +217,12 @@ options_parser =
       options[:dry_run] = true
     end
 
-    opts.on("-v", "--verbose", "prints command output while running") do
+    opts.on("-v", "--verbose", "Prints command output while running") do
       options[:verbose] = true
+    end
+
+    opts.on("--config=FILE", "Specify a custom config file") do |file|
+      options[:config_file] = file
     end
 
     opts.on_tail("--version", "Show version") do
@@ -260,5 +267,5 @@ if __FILE__ == $PROGRAM_NAME
   end
 
   # Execute gpush workflow
-  go(dry_run: options[:dry_run], verbose: options[:verbose])
+  go(dry_run: options[:dry_run], verbose: options[:verbose], config_file: options[:config_file])
 end

--- a/src/ruby/gpush.rb
+++ b/src/ruby/gpush.rb
@@ -5,6 +5,7 @@ require_relative "command" # Import the external command runner
 require_relative "gpush_error" # Import the custom error handling
 require_relative "git_helper" # Import Git helper methods
 require_relative "gpush_options_parser" # Import the options parser
+require_relative "notifier" # Import the desktop notifier
 
 EXITING_MESSAGE = "\nExiting gpush.".freeze
 
@@ -160,6 +161,7 @@ def go(dry_run: false, verbose: false, config_file: nil)
       title: "post-run failure",
       verbose:,
     )
+    Notifier.notify(false)
     puts "Exiting gpush."
     return
   end
@@ -169,6 +171,7 @@ def go(dry_run: false, verbose: false, config_file: nil)
     title: "post-run success",
     verbose:,
   )
+  Notifier.notify(true)
 
   if dry_run
     puts "《 Dry run completed 》"

--- a/src/ruby/gpush.rb
+++ b/src/ruby/gpush.rb
@@ -163,7 +163,7 @@ def go(dry_run: false, verbose: false, config_file: nil)
       title: "post-run failure",
       verbose:,
     )
-    Notifier.notify(false)
+    Notifier.notify(success: false)
     puts "Exiting gpush."
     return
   end
@@ -173,7 +173,7 @@ def go(dry_run: false, verbose: false, config_file: nil)
     title: "post-run success",
     verbose:,
   )
-  Notifier.notify(true)
+  Notifier.notify(success: true)
 
   if dry_run
     puts "《 Dry run completed 》"

--- a/src/ruby/notifier.rb
+++ b/src/ruby/notifier.rb
@@ -1,0 +1,49 @@
+# OSX native notifications of build status.
+# This is quietly skipped if you set (any value) and export this ENV var in your favorite .rc file:
+#   `export GPUSH_NO_NOTIFIER=1`
+# This only works (and is quietly skipped otherwise) if you install `terminal-notifier` with your favorite packager:
+#   `brew install terminal-notifier`
+#
+# Bonus effects for the inspired. If you set env vars GPUSH_SOUND_SUCCESS and/or GPUSH_SOUND_FAIL to the path
+# of a sound file, they will be played as needed. Suggest these two solid options:
+# https://pixabay.com/sound-effects/wah-wah-sad-trombone-6347/
+# https://pixabay.com/sound-effects/tada-fanfare-a-6313/
+# These could be baked into gpush, but grabbing your own favorites seems more fun.
+
+# frozen_string_literal: true
+module Notifier
+  def self.notify(success = true, msg = "Finished!")
+    audio_player = `which afplay`.chomp
+    audio_player = nil if audio_player.empty?
+
+    if audio_player
+      if ENV.key?("GPUSH_SOUND_SUCCESS") && File.file?(ENV["GPUSH_SOUND_SUCCESS"]) && success
+        Process.spawn(audio_player, ENV["GPUSH_SOUND_SUCCESS"])
+      end
+
+      if ENV.key?("GPUSH_SOUND_FAIL") && File.file?(ENV["GPUSH_SOUND_FAIL"]) && !success
+        Process.spawn(audio_player, ENV["GPUSH_SOUND_FAIL"])
+      end
+    end
+
+    terminal_notifier = `which terminal-notifier`.chomp
+    terminal_notifier = nil if terminal_notifier.empty?
+
+    return if terminal_notifier.nil? || ENV.key?("GPUSH_NO_NOTIFIER")
+
+    subtitle = success ? "Success" : "Fail"
+    sound = success ? "Hero" : "Basso"
+    emojis = success ? "🥳🎉🍾" : "🤨💩🙈"
+
+    args = [
+      terminal_notifier,
+      '-title', 'GPush Build',
+      '-subtitle', "#{emojis} #{subtitle} #{emojis}",
+      '-message', msg.to_s,
+      '-sound', sound,
+      '-sender', 'com.apple.terminal'
+    ]
+
+    system(*args)
+  end
+end

--- a/src/ruby/notifier.rb
+++ b/src/ruby/notifier.rb
@@ -12,17 +12,19 @@
 
 # frozen_string_literal: true
 module Notifier
-  def self.notify(success = true, msg = "Finished!")
+  def self.notify(success: true, msg: "Finished!")
     audio_player = `which afplay`.chomp
     audio_player = nil if audio_player.empty?
 
     if audio_player
-      if ENV.key?("GPUSH_SOUND_SUCCESS") && File.file?(ENV["GPUSH_SOUND_SUCCESS"]) && success
-        Process.spawn(audio_player, ENV["GPUSH_SOUND_SUCCESS"])
+      if ENV.key?("GPUSH_SOUND_SUCCESS") &&
+           File.file?(ENV.fetch("GPUSH_SOUND_SUCCESS")) && success
+        Process.spawn(audio_player, ENV.fetch("GPUSH_SOUND_SUCCESS"))
       end
 
-      if ENV.key?("GPUSH_SOUND_FAIL") && File.file?(ENV["GPUSH_SOUND_FAIL"]) && !success
-        Process.spawn(audio_player, ENV["GPUSH_SOUND_FAIL"])
+      if ENV.key?("GPUSH_SOUND_FAIL") &&
+           File.file?(ENV.fetch("GPUSH_SOUND_FAIL")) && !success
+        Process.spawn(audio_player, ENV.fetch("GPUSH_SOUND_FAIL"))
       end
     end
 
@@ -37,11 +39,16 @@ module Notifier
 
     args = [
       terminal_notifier,
-      '-title', 'GPush Build',
-      '-subtitle', "#{emojis} #{subtitle} #{emojis}",
-      '-message', msg.to_s,
-      '-sound', sound,
-      '-sender', 'com.apple.terminal'
+      "-title",
+      "GPush Build",
+      "-subtitle",
+      "#{emojis} #{subtitle} #{emojis}",
+      "-message",
+      msg.to_s,
+      "-sound",
+      sound,
+      "-sender",
+      "com.apple.terminal",
     ]
 
     system(*args)


### PR DESCRIPTION
Fixes #30

The 3 commits:
- Add a very basic notification system. This is a straight port of the old python version. It is MacOS specific for now.
- Add a CLI param for specifying a config file, and a debug config file that makes it easy to experiment with the config format. Seems like this may be useful in a number of contexts where we might need to test or tweak the config.
- Fix a bug (I think) where the default version was set to "unknown" but later on we're expecting that use case to be "local-development", unless I missed the point!

@vccoffey I'd be happy to skip the `--config` param commit if you think that's not useful. I just ended up testing with that to learn about the config options and didn't want to mess with the real config.